### PR TITLE
MGMT-16352: Adding NoPermissionsError as single component

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -35,6 +35,10 @@ module.exports = {
         __dirname,
         './src/components/technologypreview.tsx'
       ),
+      './NoPermissionsError': path.resolve(
+        __dirname,
+        './src/components/nopermissionserror.tsx'
+      ),
     },
     exclude: ['react', 'react-dom'],
     shared: [

--- a/src/components/nopermissionserror.tsx
+++ b/src/components/nopermissionserror.tsx
@@ -1,0 +1,3 @@
+import { NoPermissionsError } from '@openshift-assisted/ui-lib/ocm';
+import '../i18n';
+export default NoPermissionsError;


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16352

Trying to export all assisted UI components that we are using in uhc-portal as single components to decouple the code.