### PR TITLE
Updating frontend-component libs and add stripAllPfStyles flag to fec.config.js

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -5,6 +5,7 @@ module.exports = {
   debug: true,
   useProxy: true,
   proxyVerbose: true,
+  stripAllPfStyles: true,
   /**
    * Change accordingly to your appname in package.json.
    * The `sassPrefix` attribute is only required if your `appname` includes the dash `-` characters.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.3",
-        "@redhat-cloud-services/frontend-components-config": "^6.0.5",
+        "@redhat-cloud-services/frontend-components-config": "^6.0.17",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.4",
         "@swc/core": "^1.3.96",
         "@swc/jest": "^0.2.29",
@@ -2631,17 +2631,17 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.0.10.tgz",
-      "integrity": "sha512-h1c72gKQVLmd52ZNQ2x95UJM2ACP1bBgct3cbNW1AyygYEMoWE1x7XYEpclT/7NMdu52L7f4mw0c0sdVusPkdA==",
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.0.17.tgz",
+      "integrity": "sha512-vjK1im7aE6s7k3rBCB/wBNioRO9DtegieD78mwRTCBXJaaOvuPXm5yzg5+SIR4Q/CNlccrcjle9ISN8gSfqaLQ==",
       "dev": true,
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^3.0.4",
-        "@redhat-cloud-services/tsc-transform-imports": "^1.0.3",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^3.0.5",
+        "@redhat-cloud-services/tsc-transform-imports": "^1.0.8",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
-        "axios": "^0.28.0",
+        "axios": "^0.28.1",
         "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "chalk": "^4.1.2",
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/tsc-transform-imports": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/tsc-transform-imports/-/tsc-transform-imports-1.0.7.tgz",
-      "integrity": "sha512-ps5OL6r/8jQRThydh1lzgyUcY/7jObHK5nOhk2c9Ztb6qphjDgsm4lzcWFQcPGsdneXf9swsAF4O6vvcq810yw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/tsc-transform-imports/-/tsc-transform-imports-1.0.11.tgz",
+      "integrity": "sha512-ARk+V8G3tkM4iT4WUkwwyOPnLy6YQJBEMzPQO+RXvNFyzCqGc1h1vkGU4F/4nVhc9kC/Gt5RfBUJ5e2YbYaBfA==",
       "dev": true,
       "dependencies": {
         "glob": "10.3.3"
@@ -5234,9 +5234,9 @@
       "peer": true
     },
     "node_modules/axios": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+      "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.3",
-    "@redhat-cloud-services/frontend-components-config": "^6.0.5",
+    "@redhat-cloud-services/frontend-components-config": "^6.0.17",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.4",
     "@swc/core": "^1.3.96",
     "@swc/jest": "^0.2.29",


### PR DESCRIPTION
Try to solve CSS conflicts in the OCM UI. We have a solution which is not ideal but will unblock you.  The problem is that the assisted installer app, depends on the assisted installer UI and depends on the openshift plugin SDK. Which still requires pf4.
This makes a real mess with dependency deduplication. It means the assisted installer UI has several instances of PF installed within node modules, which makes a kind of a mess in certain webpack config that is tasked with removing PF styles dependencies from HCC UI modules.

To solve this @Hyperkid123 propose this temporary solution: https://github.com/RedHatInsights/frontend-components/pull/2019