### PR TITLE
Update Assisted UI Lib to 2.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@openshift-assisted/locales": "2.38.5",
-        "@openshift-assisted/types": "2.38.5",
-        "@openshift-assisted/ui-lib": "2.38.5",
+        "@openshift-assisted/locales": "2.39.0",
+        "@openshift-assisted/types": "2.39.0",
+        "@openshift-assisted/ui-lib": "2.39.0",
         "@redhat-cloud-services/frontend-components": "^4.1.0",
         "axios": ">=0.22.0 <1.0.0",
         "i18next": "^20.4.0",
@@ -2028,24 +2028,24 @@
       }
     },
     "node_modules/@openshift-assisted/locales": {
-      "version": "2.38.5",
-      "resolved": "https://registry.npmjs.org/@openshift-assisted/locales/-/locales-2.38.5.tgz",
-      "integrity": "sha512-L18aGx+aS09Ckxld+V9kEL+85YIjpcXr8c9oEHHMVTT5oXACA8Bn5TY6M2urG6qwJ6GArAyHfiL1l8peOV88cQ==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@openshift-assisted/locales/-/locales-2.39.0.tgz",
+      "integrity": "sha512-LqXkWXErsof7UgeFjqv70urWkIl3RC4Dk5w/js+56Eyg9ZyiKGzbKSdcDcb6SgJHSA05mnaRj/1DPc3+mChCnA==",
       "license": "Apache-2.0"
     },
     "node_modules/@openshift-assisted/types": {
-      "version": "2.38.5",
-      "resolved": "https://registry.npmjs.org/@openshift-assisted/types/-/types-2.38.5.tgz",
-      "integrity": "sha512-hGR/Ya8n+AV6gwx2s5yejhoXqxQgU9cW5o3S9IQNSCGskbrUN1PLAd8naVCg0XBAKBg6gzfqlYb7AhxM7gCsWA=="
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@openshift-assisted/types/-/types-2.39.0.tgz",
+      "integrity": "sha512-7JOvfP+Uf3gp7AwnetESBRBvv5OLmjsMJAQUsyzWP0e0Ein6Sb/VjfCA8VFYknWsxmzY/b9mMUEpfwHihu+2ww=="
     },
     "node_modules/@openshift-assisted/ui-lib": {
-      "version": "2.38.5",
-      "resolved": "https://registry.npmjs.org/@openshift-assisted/ui-lib/-/ui-lib-2.38.5.tgz",
-      "integrity": "sha512-wEzJjp7BO0ZGJxMnZECh38Ab21GMRkXbJnk2oceaq3kvQ4gGiRaTjre3yQnNRZ1iAM09f2DOWIO2POCqaU8YLA==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@openshift-assisted/ui-lib/-/ui-lib-2.39.0.tgz",
+      "integrity": "sha512-I/M76I/HgS9EPuUyoGmXKe9+tTy8ydU1G/FCVkOjsNgBve7he/OUHnK3mozsIIFeQf69Bqf8lzZkf4eZES3k+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openshift-assisted/locales": "2.38.5",
-        "@openshift-assisted/types": "2.38.5",
+        "@openshift-assisted/locales": "2.39.0",
+        "@openshift-assisted/types": "2.39.0",
         "@openshift-console/dynamic-plugin-sdk": "0.0.3",
         "@patternfly/patternfly": "5.2.0",
         "@patternfly/react-code-editor": "5.2.0",
@@ -2069,6 +2069,7 @@
         "is-in-subnet": "^4",
         "js-yaml": "^4.1.0",
         "lodash-es": "^4.17.21",
+        "parse-url": "^9.2.0",
         "prism-react-renderer": "^1.1.1",
         "react-error-boundary": "^3.1.4",
         "react-measure": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "prettier": "prettier --write src"
   },
   "dependencies": {
-    "@openshift-assisted/locales": "2.38.5",
-    "@openshift-assisted/types": "2.38.5",
-    "@openshift-assisted/ui-lib": "2.38.5",
+    "@openshift-assisted/locales": "2.39.0",
+    "@openshift-assisted/types": "2.39.0",
+    "@openshift-assisted/ui-lib": "2.39.0",
     "@redhat-cloud-services/frontend-components": "^4.1.0",
     "axios": ">=0.22.0 <1.0.0",
     "i18next": "^20.4.0",


### PR DESCRIPTION
Update Assisted UI Lib to 2.39.0

Release notes: https://github.com/openshift-assisted/assisted-installer-ui/releases/tag/v2.39.0