### PR TITLE
Update the docs URL to match mocks

### DIFF
--- a/src/components/chatbot/AsyncChatbot.tsx
+++ b/src/components/chatbot/AsyncChatbot.tsx
@@ -93,7 +93,7 @@ class AsyncChatbot implements AsyncStateManager<IAIClient> {
       streamMessages: true,
       modelName: 'OpenShift Assisted Installer',
       docsUrl:
-        'https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2025/html/installing_openshift_container_platform_with_the_assisted_installer/index',
+        'https://docs.redhat.com/en/documentation/openshift_container_platform/4.10/html/installing/installing-on-premise-with-assisted-installer#using-the-assisted-installer_installing-on-prem-assisted',
       selectionTitle: 'OpenShift Assisted Installer',
       selectionDescription:
         'Learn more about using the Assisted Installer as a simplified method for installing and managing OpenShift Container Platform clusters.',


### PR DESCRIPTION
Hello! Updating the new config to match the mock here

<img width="2230" height="1956" alt="image" src="https://github.com/user-attachments/assets/b5d6bc44-ee48-4a72-9bc1-9b87c6ea1733" />

https://issues.redhat.com/browse/RHCLOUD-42360 